### PR TITLE
Update responsive-srcset.js to support .webp

### DIFF
--- a/app/back-end/modules/render-html/handlebars/helpers/responsive-srcset.js
+++ b/app/back-end/modules/render-html/handlebars/helpers/responsive-srcset.js
@@ -29,8 +29,8 @@ function returnSrcSetAttribute (url, type, group) {
         return output;
     }
 
-    // skip GIF and SVG images
-    if (url.slice(-4) === '.gif' || url.slice(-4) === '.svg') {
+    // skip GIF, SVG, WEBP images
+    if (url.slice(-4) === '.gif' || url.slice(-4) === '.svg' || url.slice(-5) === '.webp') {
         return output;
     }
 


### PR DESCRIPTION
Today, if you add a .webp animation to your post, the responsive handlers will only show the first frame. Save bandwidth by allowing .webp instead of converting to gifs first